### PR TITLE
Add deal service upsert to Ruby gem

### DIFF
--- a/config.h
+++ b/config.h
@@ -1,0 +1,1 @@
+../../../../Headers/ruby/config.h

--- a/lib/basecrm/services/deals_service.rb
+++ b/lib/basecrm/services/deals_service.rb
@@ -105,6 +105,28 @@ module BaseCRM
       Deal.new(root[:data])
     end
 
+    # Upsert a deal
+    #
+    # post '/deals/upsert?filter_param=filter_value 
+    #
+    # Create a new deal or update an existing, based on a value of a filter or a set of filters. 
+    # At least a single filter - query parameter - is required. If no parameters are present, the request will return an error.
+    # See full docs https://developers.getbase.com/docs/rest/reference/deals
+    #
+    # @param filters [Hash] - hash contain filters, one level deep e.g. { name: 'string', 'custom_fields[field]': 'value' }
+    # @param deal [Deal, Hash] - This object's attributes describe the object to be updated or created
+    # @return [Deal] The resulting object representing updated or created resource.
+    def upsert(filters, deal)
+      validate_upsert_filters!(filters)
+      validate_type!(deal)
+
+      attributes = sanitize(deal)
+      query_string = URI.encode_www_form(filters)
+      _, _, root = @client.post("/deals/upsert?#{query_string}", attributes)
+
+      Deal.new(root[:data])
+    end
+
 
     # Delete a deal
     #
@@ -125,6 +147,11 @@ module BaseCRM
   private
     def validate_type!(deal)
       raise TypeError unless deal.is_a?(Deal) || deal.is_a?(Hash)
+    end
+
+    def validate_upsert_filters!(filters)
+      raise TypeError unless filters.is_a?(Hash)
+      raise ArgumentError, "at least one filter is required" if filters.empty?
     end
 
     def extract_params!(deal, *args)

--- a/spec/services/deals_service_spec.rb
+++ b/spec/services/deals_service_spec.rb
@@ -62,10 +62,18 @@ describe BaseCRM::DealsService do
 
   describe :upsert do
     it 'raises a TypeError if filters is nil' do
-
+      expect(client.deals.upsert(nil, { name: 'unique_name' }).to raise_error(TypeError)
     end
-    it 'raises an ArgumentError if filters is empty'
-    it 'calls the upsert route with encoded filters'
+
+    it 'raises an ArgumentError if filters is empty' do
+      expect(client.deals.upsert({}, { name: 'unique_name' }).to raise_error(ArgumentError)
+    end
+
+    it 'calls the upsert route with encoded filters' do
+      filters = { name: 'unique_name', 'custom_fields[external_id]': 'unique-1' }
+      attributes = filters.merge('custom_fields[category]': 'bags')
+      expect(client.deals.upsert(filters, attributes)).to be_instance_of BaseCRM::Deal
+    end
   end
  
   describe :destroy do

--- a/spec/services/deals_service_spec.rb
+++ b/spec/services/deals_service_spec.rb
@@ -9,6 +9,7 @@ describe BaseCRM::DealsService do
     it { should respond_to :destroy }
     it { should respond_to :find }
     it { should respond_to :update }
+    it { should respond_to :upsert }
     it { should respond_to :where }
 
   end
@@ -59,6 +60,14 @@ describe BaseCRM::DealsService do
     end
   end
 
+  describe :upsert do
+    it 'raises a TypeError if filters is nil' do
+
+    end
+    it 'raises an ArgumentError if filters is empty'
+    it 'calls the upsert route with encoded filters'
+  end
+ 
   describe :destroy do
     it "returns true on success" do
       @deal = create(:deal)


### PR DESCRIPTION
Adds the ability to send a POST to /deals/upsert as specified here https://developers.getbase.com/docs/rest/reference/deals

Plan is to merge this to master branch of carwow fork, and then send a PR back to zendesk/basecrm-ruby